### PR TITLE
Ensure collective still works if there is only one host

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,11 @@ Collective.prototype.makeConnections = function (callback) {
 
     var x = self.remote.length;
 
+	if (x === 0) {
+		callback();
+		return;
+	}
+
     self.remote.forEach(function (item) {
         self.makeConnection(item.host, item.port, function () {
             x--;

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var Collective = require('../index.js');
 /* Config */
 var host1 = {host: 'localhost', port: 8124};
 var host2 = {host: '127.0.0.1', port: 8125}; // Same host interpreted as different just for tests.
+var host3 = {host: '127.0.0.1', port: 8126}; // Same host interpreted as different just for tests.
 var all_hosts = [host1, host2];
 var collective1 = null;
 var collective2 = null;
@@ -148,9 +149,12 @@ collective1 = new Collective(host1, all_hosts, function (collective1) {
                             collective2.data,
                             ['Delete synchronization with 2 hosts failed.']);
 
-                        console.log('All tests passed.');
-
-                        process.exit();
+						var callback_run;
+						var collective3 = new Collective(host3, [host3], function (collective3) {
+							assert.ok(true, ['Callback runs when there is only one host']);
+							console.log('All tests passed.');
+							process.exit();
+						});
                     }, 500);
                 }, 500);
             }, 500);


### PR DESCRIPTION
A tiny fix: running collective in our development environment, where we don't use cluster, so we've only got one worker.   Collective then silently fails by never calling the callback function you give it in the constructor.  

In this reduntant case Collective obviously doesn't sync anything (since there are no other hosts to sync to).  But it runs fine and suffices for development.

I've included the fix and a test case.
